### PR TITLE
Tiff image server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ All other content is released under [CC-BY-4.0](https://creativecommons.org/lice
         REPOSITORY_PWD={repository password}
         PDF_JS_VIEWER_PORT={port}
         IIIF_IMAGE_SERVER_URL={cantaloupe api domain}
-        IIIF_IMAGE_SERVER_PATH={relative path to cantaloupe endpoint, if any}
+        IIIF_IMAGE_SERVER_PATH={relative path to cantaloupe endpoint, blank if none}
+        IIIF_TIFF_IMAGE_SERVER_URL{cantaloupe api domain, option for second image server to render tiff files. Keep blank if using one server for all images}
+        IIIF_TIFF_IMAGE_SERVER_PATH{relative path to cantaloupe tiff server endpoint, blank if none}
         IIIF_DOMAIN={iiif api domain}
         IIIF_PATH={relative path to iiif, should be '/iiif'}
 

--- a/config/config.js
+++ b/config/config.js
@@ -664,7 +664,7 @@ module.exports = {
         "tif": "image/tiff",
         "tiff": "image/tiff",
         "jp2": "image/jp2",
-        "jpg": "image/jpg",
+        "jpg": "image/jpeg",
         "mp3": "audio/mp3",
         "mp4": "video/mp4",
         "pdf": "application/pdf"

--- a/config/config.js
+++ b/config/config.js
@@ -202,6 +202,8 @@ module.exports = {
      */
     IIIFServerUrl: process.env.IIIF_IMAGE_SERVER_URL + process.env.IIIF_IMAGE_SERVER_PATH,
     IIIFServerDomain: process.env.IIIF_IMAGE_SERVER_URL,
+    IIIFTiffServerUrl: process.env.IIIF_TIFF_IMAGE_SERVER_URL + process.env.IIIF_TIFF_IMAGE_SERVER_PATH,
+    IIIFTiffServerDomain: process.env.IIIF_TIFF_IMAGE_SERVER_URL,
     IIIFDomain: process.env.IIIF_DOMAIN,
     IIIFUrl: process.env.IIIF_DOMAIN + process.env.IIIF_PATH,
     IIIFAPiKeyPrefix: "__",

--- a/config/express.js
+++ b/config/express.js
@@ -49,7 +49,7 @@ module.exports = function () {
     app.use(noCache());
     app.use(helmet.contentSecurityPolicy({
       directives: {
-        defaultSrc: ["'self'", config.webSocketDomain, (config.webSocketDomain+":"+config.webSocketPort), config.IIIFServerDomain, config.IIIFDomain, config.repositoryDomain, 'www.google-analytics.com', 'cdnapisec.kaltura.com', 'data:', 'blob:', 'www.du.edu', 'fonts.gstatic.com', 'use.fontawesome.com', 'http://jwpltx.com'],
+        defaultSrc: ["'self'", config.webSocketDomain, (config.webSocketDomain+":"+config.webSocketPort), config.IIIFServerDomain, config.IIIFTiffServerDomain, config.IIIFDomain, config.repositoryDomain, 'www.google-analytics.com', 'cdnapisec.kaltura.com', 'data:', 'blob:', 'www.du.edu', 'fonts.gstatic.com', 'use.fontawesome.com', 'http://jwpltx.com'],
         styleSrc: ["'self'", "'unsafe-inline'", 'maxcdn.bootstrapcdn.com', 'use.fontawesome.com', 'vjs.zencdn.net', 'code.jquery.com', 'fonts.googleapis.com'],
         scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'www.google-analytics.com', 'vjs.zencdn.net', 'use.fontawesome.com', 'code.jquery.com', 'http://p.jwpcdn.com'],
         fontSrc: ["'self'", 'data:', 'fonts.gstatic.com', 'use.fontawesome.com']

--- a/discovery/service.js
+++ b/discovery/service.js
@@ -525,7 +525,8 @@ exports.getManifestObject = function(pid, index, page, apikey, callback) {
             downloadFileName: parts[key].title,
             resourceUrl: resourceUrl,
             thumbnailUrl: config.rootUrl + "/datastream/" + object.pid + "/tn/" + parts[key].order,
-            pageCount: pageCount
+            pageCount: pageCount,
+            extension: AppHelper.getFileExtensionFromFilePath(parts[key].object)
           });
         }
 
@@ -567,7 +568,8 @@ exports.getManifestObject = function(pid, index, page, apikey, callback) {
           resourceID: object.pid,
           resourceUrl: resourceUrl,
           thumbnailUrl: config.rootUrl + "/datastream/" + object.pid + "/tn",
-          pageCount: pageCount
+          pageCount: pageCount,
+          extension: AppHelper.getFileExtensionFromFilePath(object.object)
         });
 
         IIIF.getManifest(container, children, apikey, function(error, manifest) {

--- a/libs/IIIF.js
+++ b/libs/IIIF.js
@@ -393,13 +393,14 @@ var getThumbnailObject = function(container, object, apikey, page=null) {
 
 	apikey = apikey ? ("?key=" + apikey) : "";
 
-	thumbnail["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + "/full/" + config.IIIFThumbnailWidth + ",/0/default.jpg" + page + apikey;
+	let imageServerUrl = (object.extension == "tif" || object.extension == "tiff") ? config.IIIFTiffServerUrl : config.IIIFServerUrl;
+	thumbnail["@id"] = imageServerUrl + "/iiif/2/" + object.resourceID + "/full/" + config.IIIFThumbnailWidth + ",/0/default.jpg" + page + apikey;
 	thumbnail["@type"] = config.IIIFObjectTypes["still image"];
 	if(config.IIIFThumbnailHeight) {thumbnail["height"] = config.IIIFThumbnailHeight}
 	if(config.IIIFThumbnailWidth) {thumbnail["width"] = config.IIIFThumbnailWidth}
 
 	service["@context"] = "http://iiif.io/api/image/2/context.json";
-	service["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + apikey;
+	service["@id"] = imageServerUrl + "/iiif/2/" + object.resourceID + apikey;
 	service["protocol"] = "http://iiif.io/api/image";
 
 	if(config.IIIFThumbnailHeight) {service["height"] = config.IIIFThumbnailHeight}
@@ -423,13 +424,6 @@ var getImageCanvas = function(container, object, apikey) {
 	canvas["@id"] = config.IIIFUrl + "/" + container.resourceID + "/canvas/c" + object.sequence;
 	canvas["@type"] = "sc:Canvas";
 	canvas["label"] = object.label;
-
-	//canvas["thumbnail"] = getThumbnailObject(container, object);
-	// canvas["rendering"] = {
-	// 	"@id": object.resourceUrl + "/" + object.downloadFileName,
-	// 	"format": object.format,
-	// 	"label": "Download Image"
-	// }
 	canvas["thumbnail"] = getThumbnailObject(container, object, apikey);
 	canvas['images'] = [];
 
@@ -438,16 +432,13 @@ var getImageCanvas = function(container, object, apikey) {
 	image["motivation"] = "sc:painting";
 
 	let imageServerUrl = (object.extension == "tif" || object.extension == "tiff") ? config.IIIFTiffServerUrl : config.IIIFServerUrl;
-		console.log("TEST iiif: extension is", object.extension)
-		console.log("TEST iiif: image server url is", imageServerUrl)
 	resource["@id"] = imageServerUrl + "/iiif/2/" + object.resourceID + "/full/!1024,1024/0/default.jpg" + apikey;
 
 	resource["@type"] = object.type; 
 	resource["format"] = object.format; 
 
 	service["@context"] = "";
-	service["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + apikey;	// cantaloupe
-	service["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + apikey
+	service["@id"] = imageServerUrl + "/iiif/2/" + object.resourceID + apikey
 
 	resource["service"] = service;
 

--- a/libs/IIIF.js
+++ b/libs/IIIF.js
@@ -437,8 +437,11 @@ var getImageCanvas = function(container, object, apikey) {
 	image["@type"] =  "oa:Annotation";
 	image["motivation"] = "sc:painting";
 
-	resource["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + "/full/!1024,1024/0/default.jpg" + apikey;
-	//resource["@id"] = config.IIIFServerUrl + "/iiif/2/" + object.resourceID + apikey + "/full/full/0/default.jpg";
+	let imageServerUrl = (object.extension == "tif" || object.extension == "tiff") ? config.IIIFTiffServerUrl : config.IIIFServerUrl;
+		console.log("TEST iiif: extension is", object.extension)
+		console.log("TEST iiif: image server url is", imageServerUrl)
+	resource["@id"] = imageServerUrl + "/iiif/2/" + object.resourceID + "/full/!1024,1024/0/default.jpg" + apikey;
+
 	resource["@type"] = object.type; 
 	resource["format"] = object.format; 
 

--- a/libs/helper.js
+++ b/libs/helper.js
@@ -314,7 +314,7 @@ var getContentType = function(datastream, object, part, mimeType) {
   }
   // Thumbnail datastream, use specified file type
   if(datastream.toLowerCase() == "tn") {
-    contentType = "image/" + config.thumbnailFileExtension || "jpg";
+    contentType = "image/" + config.thumbnailFileExtension || "jpeg";
   }
   // File type specific datasreeam (mp3, jpg, etc)
   else if(datastream.toLowerCase() != "object") {


### PR DESCRIPTION
# What does this Pull Request do?

Adds a second image server option to render tiff files 

# What's new?
* new .env fields
IIIF_TIFF_IMAGE_SERVER_URL=
IIIF_TIFF_IMAGE_SERVER_PATH=

Example:
If using a single image server, use the same settings for the above fields as the primary image server:
IIIF_IMAGE_SERVER_URL=
IIIF_IMAGE_SERVER_PATH=

# How should this be tested?
Load a tiff image via the object viewer or datastream API route, the app should utilize the secondary tiff server
All other image objects use the primary image server for rendering

